### PR TITLE
Add GitHub Actions R package checks

### DIFF
--- a/.github/workflows/R-CMD-check-standard.yaml
+++ b/.github/workflows/R-CMD-check-standard.yaml
@@ -1,0 +1,49 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  workflow_dispatch:
+
+name: R-CMD-check-standard.yaml
+
+permissions: read-all
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: macos-latest,   r: 'release'}
+          - {os: windows-latest, r: 'release'}
+          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-latest,   r: 'release'}
+          - {os: ubuntu-latest,   r: 'oldrel-1'}
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rcmdcheck
+          needs: check
+
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          upload-snapshots: true
+          build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,0 +1,33 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+name: R-CMD-check.yaml
+
+permissions: read-all
+
+jobs:
+  R-CMD-check:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rcmdcheck
+          needs: check
+
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          upload-snapshots: true
+          build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'

--- a/README.Rmd
+++ b/README.Rmd
@@ -16,6 +16,7 @@ knitr::opts_chunk$set(
 # smimodel <img src="man/figures/logo.png" align="right" height="138" alt="" />
 
 <!-- badges: start -->
+[![R-CMD-check](https://github.com/nuwani-palihawadana/smimodel/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/nuwani-palihawadana/smimodel/actions/workflows/R-CMD-check.yaml)
 <!-- badges: end -->
 
 The R package *smimodel* provides functions to estimate Sparse Multiple Index (SMI) Models for nonparametric forecasting/prediction. The SMI Modelling algorithm simultaneously performs optimal predictor selection (hence "sparse") and predictor grouping, enabling parsimonious forecasting/prediction models in a high-dimensional context.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 # smimodel <img src="man/figures/logo.png" align="right" height="138" alt="" />
 
 <!-- badges: start -->
-
+[![R-CMD-check](https://github.com/nuwani-palihawadana/smimodel/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/nuwani-palihawadana/smimodel/actions/workflows/R-CMD-check.yaml)
 <!-- badges: end -->
 
 The R package *smimodel* provides functions to estimate Sparse Multiple


### PR DESCRIPTION
* `.github/workflows/R-CMD-check-standard.yaml` runs checks on macos (R-release), windows (R-release) and ubuntu (R-devel, R-release, and R-oldrel). It is started manually (typically before CRAN releases) using the GitHub Actions tab.
* `.github/workflows/R-CMD-check.yaml` runs checks on ubuntu (R-release) after every push to main and every pull request. This also updates the badge in the README with the check status.